### PR TITLE
Add boost and sabotage buttons with progress bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,14 +14,14 @@
             align-items: center;
             justify-content: center;
             min-height: 100vh;
-            background-color: #111827; /* Darker background for contrast */
-            color: #d1d5db; /* Tailwind gray-300 */
+            background-color: #f8fafc; /* Light background */
+            color: #1f2937; /* Tailwind gray-800 */
             text-align: center;
             padding: 1rem;
             overflow: hidden;
         }
         .container {
-            background-color: #1f2937; /* Tailwind gray-800 */
+            background-color: #ffffff; /* Light container */
             padding: 2rem;
             border-radius: 1rem; /* Tailwind rounded-2xl */
             box-shadow: 0 20px 25px -5px rgba(0,0,0,0.3), 0 10px 10px -5px rgba(0,0,0,0.2); /* Enhanced shadow */
@@ -30,14 +30,14 @@
             position: relative;
             overflow: hidden;
             transition: filter 0.3s ease-in-out, background 2s ease-in-out;
-            border: 1px solid #374151; /* Tailwind gray-700 border */
+            border: 1px solid #e5e7eb; /* Light border */
             animation: pulseBg 10s infinite alternate;
         }
 
         @keyframes pulseBg {
-            0% { background-color: #1f2937; } /* gray-800 */
-            50% { background-color: #374151; } /* gray-700 */
-            100% { background-color: #1f2937; } /* gray-800 */
+            0% { background-color: #ffffff; }
+            50% { background-color: #f1f5f9; }
+            100% { background-color: #ffffff; }
         }
 
         .container.modal-open {
@@ -64,7 +64,7 @@
         }
         .status-text {
             font-size: 1.125rem; /* Tailwind text-lg */
-            color: #9ca3af; /* Tailwind gray-400 */
+            color: #475569; /* Tailwind slate-600 */
             transition: opacity 0.3s ease-in-out;
         }
         .action-button, .reset-button, .modal-send-button {
@@ -106,10 +106,36 @@
             background: linear-gradient(145deg, #4b5563, #374151);
             transform: translateY(-2px);
         }
+        .boost-button {
+            background: linear-gradient(145deg, #34d399, #10b981); /* Green gradient */
+        }
+        .boost-button:hover {
+            background: linear-gradient(145deg, #10b981, #059669);
+        }
+        .sabotage-button {
+            background: linear-gradient(145deg, #fbbf24, #f59e0b); /* Amber gradient */
+        }
+        .sabotage-button:hover {
+            background: linear-gradient(145deg, #f59e0b, #d97706);
+        }
+        .progress-bar {
+            width: 100%;
+            height: 1rem;
+            background-color: #e5e7eb;
+            border-radius: 0.5rem;
+            overflow: hidden;
+            margin-bottom: 1rem;
+        }
+        .progress-fill {
+            height: 100%;
+            width: 70%;
+            background-image: linear-gradient(to right, #a855f7, #ec4899);
+            transition: width 0.3s ease-in-out;
+        }
         .footer-text {
             margin-top: 2rem;
             font-size: 0.875rem; /* Tailwind text-sm */
-            color: #6b7280; /* Tailwind gray-500 */
+            color: #64748b; /* Tailwind slate-500 */
         }
 
         @keyframes shake { 0%, 100% { transform: translateX(0); } 25% { transform: translateX(-5px); } 50% { transform: translateX(5px); } 75% { transform: translateX(-3px); } }
@@ -124,12 +150,12 @@
             100% { transform: translateY(100vh) translateX(calc(var(--random-x) * 1px)) rotateZ(720deg) scale(1); opacity: 0; }
         }
 
-        .modal-overlay { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background-color: rgba(0, 0, 0, 0.75); display: none; align-items: center; justify-content: center; z-index: 1000; padding: 1rem; }
-        .modal-content { background-color: #1f2937; /* Dark modal */ color: #d1d5db; padding: 2.5rem; border-radius: 1rem; box-shadow: 0 25px 50px -12px rgba(0,0,0,0.5); width: 100%; max-width: 520px; text-align: left; position: relative; border: 1px solid #4b5563; }
-        .modal-title { font-size: 2rem; font-weight: 700; color: #f3f4f6; text-align: center; margin-bottom: 0.75rem; }
-        .modal-subtitle { font-size: 1.125rem; color: #9ca3af; text-align: center; margin-bottom: 2rem; }
-        .letter-title { font-size: 1.25rem; font-weight: 600; color: #e5e7eb; margin-top: 1rem; margin-bottom: 1rem; border-bottom: 1px solid #4b5563; padding-bottom: 0.75rem; }
-        .letter-body p { margin-bottom: 1rem; line-height: 1.7; color: #d1d5db; }
+        .modal-overlay { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background-color: rgba(0, 0, 0, 0.5); display: none; align-items: center; justify-content: center; z-index: 1000; padding: 1rem; }
+        .modal-content { background-color: #ffffff; color: #1f2937; padding: 2.5rem; border-radius: 1rem; box-shadow: 0 25px 50px -12px rgba(0,0,0,0.2); width: 100%; max-width: 520px; text-align: left; position: relative; border: 1px solid #e5e7eb; }
+        .modal-title { font-size: 2rem; font-weight: 700; color: #1f2937; text-align: center; margin-bottom: 0.75rem; }
+        .modal-subtitle { font-size: 1.125rem; color: #475569; text-align: center; margin-bottom: 2rem; }
+        .letter-title { font-size: 1.25rem; font-weight: 600; color: #1f2937; margin-top: 1rem; margin-bottom: 1rem; border-bottom: 1px solid #e5e7eb; padding-bottom: 0.75rem; }
+        .letter-body p { margin-bottom: 1rem; line-height: 1.7; color: #374151; }
         .modal-send-button { background-image: linear-gradient(to right, #ef4444, #c026d3); /* Red to Purple gradient */ display: block; margin: 2rem auto 0; }
         .modal-send-button:hover { background-image: linear-gradient(to right, #dc2626, #a31caf); transform: translateY(-2px); }
     </style>
@@ -139,21 +165,30 @@
         <h1 class="text-4xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-purple-400 via-pink-500 to-red-500 mb-3">The 'Original Genius'</h1>
         <h2 class="text-3xl font-semibold text-indigo-400 mb-8">Retention Tracker</h2>
 
-        <p class="text-gray-400 mb-4">
-            Because some ideas are just too good to be "improved" into oblivion.
+        <p class="text-gray-600 mb-4">
+            Because some ideas deserve a parade, not a "makeover".
         </p>
         <p class="text-gray-500 text-sm mb-8">
-            Current baseline: Keep <strong>at least 70%</strong> of the original brilliance.
+            Current baseline: keep <strong>at least 70%</strong> of the original brilliance.
         </p>
 
         <div id="percentageDisplay" class="percentage-display">70%</div>
+        <div class="progress-bar">
+            <div id="progressBar" class="progress-fill"></div>
+        </div>
         <div class="status-message-container">
             <span id="statusEmoji" class="status-emoji">😐</span>
-            <span id="statusText" class="status-text">Original vision holding strong!</span>
+            <span id="statusText" class="status-text">Baseline secure and ready for glory!</span>
         </div>
 
         <button id="angerButton" class="action-button">
-            Boss 'suggested' changes... (+1%)
+            Manager has a 'fun' idea... (+1%)
+        </button>
+        <button id="boostButton" class="action-button boost-button">
+            Burst of inspiration! (+5%)
+        </button>
+        <button id="sabotageButton" class="action-button sabotage-button">
+            Manager panic! (-5%)
         </button>
         <button id="resetButton" class="reset-button">
             Start Over?
@@ -189,6 +224,9 @@
         const statusEmoji = document.getElementById('statusEmoji');
         const statusText = document.getElementById('statusText');
         const angerButton = document.getElementById('angerButton');
+        const boostButton = document.getElementById('boostButton');
+        const sabotageButton = document.getElementById('sabotageButton');
+        const progressBar = document.getElementById('progressBar');
         const resetButton = document.getElementById('resetButton');
         const trackerContainer = document.getElementById('trackerContainer');
         const resignationModal = document.getElementById('resignationModal');
@@ -214,7 +252,7 @@
                 volume: -10
             }).toDestination();
         }
-        
+
         // Call initializeSounds on first user interaction (e.g., button click)
         // or on window load if allowed by browser. For robustness, often best on interaction.
         let soundsInitialized = false;
@@ -228,43 +266,47 @@
             let emoji = '😐'; // Default emoji
 
             if (currentPercentage < INITIAL_PERCENTAGE) {
-                newStatus = "Dipping below baseline! Reclaim the genius!";
+                newStatus = "Code meltdown! Quick, rescue the brilliance!";
                 percentageColor = '#f87171'; // Red-400
-                newButtonText = "RESCUE MISSION! (+1%)";
+                newButtonText = "SOUND THE ALARMS! (+1%)";
                 emoji = '😟';
             } else if (currentPercentage === INITIAL_PERCENTAGE) {
-                newStatus = `Holding strong at ${INITIAL_PERCENTAGE}%! Keep it up!`;
-                newButtonText = "Boss 'suggested' changes... (+1%)";
+                newStatus = `Baseline secured! Beware incoming 'suggestions'.`;
+                newButtonText = "Manager has a 'fun' idea... (+1%)";
                 emoji = '😐';
             } else if (currentPercentage > INITIAL_PERCENTAGE && currentPercentage <= 80) {
-                newStatus = "Steadily reclaiming the masterpiece!";
+                newStatus = "Reclaiming genius, one 'unhelpful tip' at a time!";
                 percentageColor = '#60a5fa'; // Blue-400
-                newButtonText = "MORE ORIGINALITY! (+1%)";
+                newButtonText = "More genius, less feedback! (+1%)";
                 emoji = '🙂';
             } else if (currentPercentage > 80 && currentPercentage < 90) {
-                newStatus = "The true vision is shining through!";
+                newStatus = "That sparkle is pure genius breaking free!";
                 percentageColor = '#34d399'; // Emerald-400
-                newButtonText = "ALMOST THERE! (+1%)";
+                newButtonText = "Nearly legendary! (+1%)";
                 emoji = '😊';
             } else if (currentPercentage >= 90 && currentPercentage < 100) {
-                newStatus = "So close to 100% pure, unadulterated genius!";
+                newStatus = "99% brilliance, 1% chance of manager interference!";
                 percentageColor = '#a78bfa'; // Violet-400
-                newButtonText = "FINAL PUSH! (+1%)";
+                newButtonText = "Almost at genius overload! (+1%)";
                 emoji = '🤩';
             } else if (currentPercentage === 100) {
-                newStatus = "100% ORIGINAL GENIUS! Time to hit 'SEND!' on that... idea? 😉";
+                newStatus = "100% Original Genius! Frame it and ship it!";
                 percentageColor = '#facc15'; // Yellow-400
-                newButtonText = "PERFECTION!";
+                newButtonText = "MASTERPIECE!";
                 emoji = '🥳';
                 angerButton.disabled = true;
+                boostButton.disabled = true;
+                sabotageButton.disabled = true;
                 resetButton.style.display = 'inline-block';
                 celebrateMilestone();
-            } else { 
-                newStatus = `BEYOND 100%?! ${currentPercentage}%! Unstoppable!`;
+            } else {
+                newStatus = `OVERLOAD! ${currentPercentage}% genius can't be contained!`;
                 percentageColor = '#ec4899'; // Pink-500
-                newButtonText = "LEGENDARY!";
+                newButtonText = "IMMORTAL!";
                 emoji = '🤯';
                 angerButton.disabled = true;
+                boostButton.disabled = true;
+                sabotageButton.disabled = true;
                 resetButton.style.display = 'inline-block';
             }
 
@@ -275,20 +317,31 @@
 
             angerButton.textContent = newButtonText;
             percentageDisplay.style.color = percentageColor;
+            progressBar.style.width = Math.min(currentPercentage, 100) + '%';
+
+            if (currentPercentage >= 100) {
+                angerButton.disabled = true;
+                boostButton.disabled = true;
+                sabotageButton.disabled = true;
+            } else {
+                angerButton.disabled = false;
+                boostButton.disabled = false;
+                sabotageButton.disabled = false;
+            }
         }
 
         function screenShake() {
             trackerContainer.classList.add('shake-effect');
             setTimeout(() => trackerContainer.classList.remove('shake-effect'), 250);
         }
-        
+
         function createConfettiParticle() {
             const particle = document.createElement('div');
             particle.classList.add('confetti-particle');
-            
+
             const randomColor = confettiColors[Math.floor(Math.random() * confettiColors.length)];
             particle.style.backgroundColor = randomColor;
-            
+
             const startX = Math.random() * window.innerWidth;
             particle.style.left = startX + 'px';
             particle.style.top = '-20px'; // Start above screen
@@ -301,12 +354,12 @@
             const size = Math.random() * 10 + 6; // 6px to 16px
             particle.style.width = size + 'px';
             particle.style.height = size + 'px';
-            
-            const fallDuration = Math.random() * 2.5 + 2; 
+
+            const fallDuration = Math.random() * 2.5 + 2;
             particle.style.animationDuration = fallDuration + 's';
 
             document.body.appendChild(particle);
-            
+
             setTimeout(() => particle.remove(), fallDuration * 1000 + 500); // Add buffer for animation
         }
 
@@ -318,7 +371,7 @@
             setTimeout(() => percentageDisplay.classList.remove('celebrate-text-animation'), 800);
 
             for (let i = 0; i < 100; i++) { // MOAR CONFETTI!
-                setTimeout(() => createConfettiParticle(), i * 20); 
+                setTimeout(() => createConfettiParticle(), i * 20);
             }
             showModal();
         }
@@ -342,7 +395,7 @@
                 clickSynth.triggerAttackRelease('C5', '8n');
             }
 
-            if (currentPercentage < 100) { 
+            if (currentPercentage < 100) {
                 currentPercentage++;
                 updateDisplay();
                 screenShake();
@@ -351,14 +404,46 @@
             }
         });
 
+        boostButton.addEventListener('click', () => {
+            if (!soundsInitialized) {
+                initializeSounds();
+                soundsInitialized = true;
+            }
+            if (soundsInitialized && clickSynth) {
+                clickSynth.triggerAttackRelease('E5', '8n');
+            }
+            if (currentPercentage < 100) {
+                currentPercentage = Math.min(currentPercentage + 5, 105);
+                updateDisplay();
+                screenShake();
+            }
+        });
+
+        sabotageButton.addEventListener('click', () => {
+            if (!soundsInitialized) {
+                initializeSounds();
+                soundsInitialized = true;
+            }
+            if (soundsInitialized && clickSynth) {
+                clickSynth.triggerAttackRelease('G3', '8n');
+            }
+            if (currentPercentage > 0) {
+                currentPercentage = Math.max(currentPercentage - 5, 0);
+                updateDisplay();
+                screenShake();
+            }
+        });
+
         resetButton.addEventListener('click', () => {
             currentPercentage = INITIAL_PERCENTAGE;
             angerButton.disabled = false;
+            boostButton.disabled = false;
+            sabotageButton.disabled = false;
             resetButton.style.display = 'none';
             const existingConfetti = document.body.querySelectorAll('.confetti-particle');
             existingConfetti.forEach(c => c.remove());
-            hideModal(); 
-            updateDisplay(); 
+            hideModal();
+            updateDisplay();
         });
 
         modalSendButton.addEventListener('click', () => { // Changed ID
@@ -369,7 +454,7 @@
         });
 
         resignationModal.addEventListener('click', (event) => {
-            if (event.target === resignationModal) { 
+            if (event.target === resignationModal) {
                 hideModal();
             }
         });


### PR DESCRIPTION
## Summary
- add a colorful progress bar below the percentage display
- introduce Boost and Sabotage buttons for quick ±5% changes
- update styles for new buttons and progress bar
- hook up event handlers to keep the tracker interactive

## Testing
- `git status --short`
